### PR TITLE
Use powershell_script rather than powershell as the resource name

### DIFF
--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -17,7 +17,7 @@ action :create do
       end
     end
 
-    powershell "create_domain_#{new_resource.name}" do
+    powershell_script "create_domain_#{new_resource.name}" do
       code cmd
     end
 
@@ -43,7 +43,7 @@ action :delete do
       end
     end
 
-    powershell "remove_domain_#{new_resource.name}" do
+    powershell_script "remove_domain_#{new_resource.name}" do
       code cmd
     end
 
@@ -62,7 +62,7 @@ action :join do
       Chef::Log.error("The computer is already joined to the domain")
       new_resource.updated_by_last_action(false)
     else
-      powershell "join_#{new_resource.name}" do
+      powershell_script "join_#{new_resource.name}" do
         if node[:os_version] >= "6.2"
           code <<-EOH
             $secpasswd = ConvertTo-SecureString '#{new_resource.domain_pass}' -AsPlainText -Force
@@ -87,7 +87,7 @@ end
 
 action :unjoin do
   if computer_exists?
-    powershell "unjoin_#{new_resource.name}" do
+    powershell_script "unjoin_#{new_resource.name}" do
       code <<-EOH
       $secpasswd = ConvertTo-SecureString '#{new_resource.domain_pass}' -AsPlainText -Force
       $mycreds = New-Object System.Management.Automation.PSCredential ('#{new_resource.domain_user}', $secpasswd)


### PR DESCRIPTION
This is now in core Chef as of 11.6.0 and this cookbook does not declare a dependency on the powershell cookbook.
