### PR TITLE
Better logging to support idempotence

### DIFF
--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -29,7 +29,7 @@ require 'mixlib/shellout'
 
 action :create do
   if exists?
-    Chef::Log.error("The object already exists")
+    Chef::Log.debug("The object already exists")
     new_resource.updated_by_last_action(false)
   else
     cmd = "dsadd"
@@ -109,7 +109,7 @@ action :delete do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The object has already been removed")
+    Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
 end

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -29,7 +29,7 @@ require 'mixlib/shellout'
 
 action :create do
   if exists?
-    Chef::Log.error("The object already exists")
+    Chef::Log.debug("The object already exists")
     new_resource.updated_by_last_action(false)
   else
     cmd = "dsadd"
@@ -111,7 +111,7 @@ action :delete do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The object has already been removed")
+    Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
 end

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -86,7 +86,7 @@ action :join do
     new_resource.updated_by_last_action(false)
   else
     if computer_exists?
-      Chef::Log.error("The computer is already joined to the domain")
+      Chef::Log.debug("The computer is already joined to the domain")
       new_resource.updated_by_last_action(false)
     else
       powershell_script "join_#{new_resource.name}" do
@@ -124,7 +124,7 @@ action :unjoin do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The computer is already a member of a workgroup")
+    Chef::Log.debug("The computer is already a member of a workgroup")
     new_resource.updated_by_last_action(false)
   end
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -29,7 +29,7 @@ require 'mixlib/shellout'
 
 action :create do
   if exists?
-    Chef::Log.error("The object already exists")
+    Chef::Log.debug("The object already exists")
     new_resource.updated_by_last_action(false)
   else
     cmd = "dsadd"
@@ -111,7 +111,7 @@ action :delete do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The object has already been removed")
+    Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
 end

--- a/providers/ou.rb
+++ b/providers/ou.rb
@@ -31,7 +31,7 @@ action :create do
   if parent?
   # indent all
     if exists?
-      Chef::Log.error("The object already exists")
+      Chef::Log.debug("The object already exists")
       new_resource.updated_by_last_action(false)
     else
       cmd = "dsadd"
@@ -117,7 +117,7 @@ action :delete do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The object has already been removed")
+    Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -29,7 +29,7 @@ require 'mixlib/shellout'
 
 action :create do
   if exists?
-    Chef::Log.error("The object already exists")
+    Chef::Log.debug("The object already exists")
     new_resource.updated_by_last_action(false)
   else
     cmd = "dsadd"
@@ -111,7 +111,7 @@ action :delete do
 
     new_resource.updated_by_last_action(true)
   else
-    Chef::Log.error("The object has already been removed")
+    Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
 end


### PR DESCRIPTION
Some of the error calls in the various exists? checks were unwarranted since they weren't actually errors. Since Chef is supposed to be idempotent, multiple calls to, for instance, create the same user shouldn't be considered an error.
