### PR TITLE
Add support for Enum and numeric values in command options

### DIFF
--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -27,6 +27,7 @@
 
 require 'mixlib/shellout'
 
+ENUM_NAMES = %w{Win2003 Win2008 Win2008R2 Win2012 Win2012R2 Default}
 
 action :create do
 
@@ -47,13 +48,7 @@ action :create do
       cmd << " -ReplicaOrNewDomain:#{new_resource.replica_type}"
     end
 
-    new_resource.options.each do |option, value|
-      if value.nil?
-        cmd << " -#{option}"
-      else
-        cmd << " -#{option} '#{value}'"
-      end
-    end
+    cmd << format_options(new_resource.options)
 
     powershell_script "create_domain_#{new_resource.name}" do
       code cmd
@@ -73,13 +68,7 @@ action :delete do
       cmd << " -DemoteOperationMasterRole"
     end
 
-    new_resource.options.each do |option, value|
-      if value.nil?
-        cmd << " -#{option}"
-      else
-        cmd << " -#{option} '#{value}'"
-      end
-    end
+    cmd << format_options(new_resource.options)
 
     powershell_script "remove_domain_#{new_resource.name}" do
       code cmd
@@ -179,6 +168,18 @@ def create_command
         "domain"
       when "replica"
         "replica"
+    end
+  end
+end
+
+def format_options(options)
+  options.reduce('') do |cmd, (option, value)|
+    if value.nil?
+      cmd << " -#{option}"
+    elsif ENUM_NAMES.include?(value) || value.is_a?(Numeric)
+      cmd << " -#{option} #{value}"
+    else
+      cmd << " -#{option} '#{value}'"
     end
   end
 end


### PR DESCRIPTION
Some options, for example ForestMode, require values in Enum format:

```
Install-ADDSForest -DomainName example.com -DomainMode Win2008 -ForestMode Win2008 -InstallDNS
```
