### PR TITLE
Use main branch for delivery workflow

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -9,8 +9,8 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@master
+      uses: actions/checkout@main
     - name: Run Chef Delivery
-      uses: actionshub/chef-delivery@master
+      uses: actionshub/chef-delivery@main
       env:
         CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@main
+      uses: actions/checkout@v2
     - name: Run Chef Delivery
       uses: actionshub/chef-delivery@main
       env:


### PR DESCRIPTION
### Description

This PR sets the branch to main instead of master for the delivery workflow, since they were renamed in their respective projects.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
