### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,1 +1,1 @@
-remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"
+remote_file = 'https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CHANGELOG for windows_ad
 
+## Unreleased
+
+- resolved cookstyle error: .delivery/project.toml:1:15 convention: `Style/StringLiterals`
+- resolved cookstyle error: resources/computer.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/computer.rb:21:1 refactor: `Chef/Style/TrueClassFalseClassResourceProperties`
+- resolved cookstyle error: resources/computer.rb:23:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire`
+- resolved cookstyle error: resources/computer.rb:100:12 refactor: `Chef/Modernize/ShellOutHelper`
+- resolved cookstyle error: resources/computer.rb:112:13 refactor: `Chef/Modernize/ShellOutHelper`
+- resolved cookstyle error: resources/contact.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/contact.rb:20:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire`
+- resolved cookstyle error: resources/domain.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/domain.rb:15:1 refactor: `Chef/Style/TrueClassFalseClassResourceProperties`
+- resolved cookstyle error: resources/domain.rb:22:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire`
+- resolved cookstyle error: resources/domain.rb:80:13 refactor: `Chef/Modernize/ShellOutHelper`
+- resolved cookstyle error: resources/domain.rb:85:12 refactor: `Chef/Modernize/ShellOutHelper`
+- resolved cookstyle error: resources/domain.rb:91:15 refactor: `Chef/Modernize/ShellOutHelper`
+- resolved cookstyle error: resources/group.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/group.rb:20:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire`
+- resolved cookstyle error: resources/group_member.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/ou.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/ou.rb:20:19 refactor: `Chef/Modernize/FoodcriticComments`
+- resolved cookstyle error: resources/ou.rb:21:18 convention: `Layout/TrailingWhitespace`
+- resolved cookstyle error: resources/ou_2008.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/ou_2012.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/user.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: test/cookbooks/windows_ad_test/recipes/setup_forest.rb:19:40 refactor: `Chef/Style/ImmediateNotificationTiming`
+
 ## 0.7.2
 
 * Add compatibility for Chef 16

--- a/resources/computer.rb
+++ b/resources/computer.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_computer
 provides :windows_ad_computer
+unified_mode true
 
 default_action :create
 
@@ -18,9 +19,7 @@ property :options, Hash, default: {}
 property :cmd_user, String
 property :cmd_pass, String
 property :cmd_domain, String
-property :restart, [TrueClass, FalseClass], required: true
-
-require 'mixlib/shellout'
+property :restart, [true, false], required: true
 
 action :create do
   if exists?
@@ -97,7 +96,7 @@ end
 
 action_class do
   def computer_exists?
-    comp = Mixlib::ShellOut.new('powershell.exe -command \"get-wmiobject -class win32_computersystem -computername . | select domain\"').run_command
+    comp = shell_out('powershell.exe -command \"get-wmiobject -class win32_computersystem -computername . | select domain\"')
     stdout = comp.stdout.downcase
     Chef::Log.debug("computer_exists? is #{stdout.downcase}")
     stdout.include?(new_resource.domain_name.downcase)
@@ -109,7 +108,7 @@ action_class do
       Chef::Log.warn('Unable to determine specific OS version. Windows 7 does not have the native tools to query if the domain exists. Assuming domain exists.')
       return true
     end
-    check = Mixlib::ShellOut.new("netdom query /domain:#{new_resource.domain_name} /userD:#{new_resource.domain_user} /passwordd:#{new_resource.domain_pass} dc").run_command
+    check = shell_out("netdom query /domain:#{new_resource.domain_name} /userD:#{new_resource.domain_user} /passwordd:#{new_resource.domain_pass} dc")
     Chef::Log.debug("netdom query /domain:#{new_resource.domain_name} /userD:#{new_resource.domain_user} /passwordd:#{new_resource.domain_pass} dc")
     Chef::Log.debug("check.stdout.include is #{check.stdout}")
     check.stdout.include? 'The command completed successfully.'

--- a/resources/contact.rb
+++ b/resources/contact.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_contact
 provides :windows_ad_contact
+unified_mode true
 
 default_action :create
 
@@ -16,8 +17,6 @@ property :options, Hash, default: {}
 property :cmd_user, String
 property :cmd_pass, String
 property :cmd_domain, String
-
-require 'mixlib/shellout'
 
 action :create do
   if exists?

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_group
 provides :windows_ad_group
+unified_mode true
 
 default_action :create
 
@@ -16,8 +17,6 @@ property :options, Hash, default: {}
 property :cmd_user, String
 property :cmd_pass, String
 property :cmd_domain, String
-
-require 'mixlib/shellout'
 
 action :create do
   if exists?

--- a/resources/group_member.rb
+++ b/resources/group_member.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_group_member
 provides :windows_ad_group_member
+unified_mode true
 
 default_action :add
 

--- a/resources/ou.rb
+++ b/resources/ou.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_ou
 provides :windows_ad_ou
+unified_mode true
 
 default_action :create
 
@@ -17,7 +18,7 @@ property :cmd_user, String
 property :cmd_pass, String
 property :cmd_domain, String
 
-action :create do # ~FC017
+action :create do
   require 'chef/win32/version'
   win_ver = Chef::ReservedNames::Win32::Version.new
   if win_ver.windows_server_2008? || win_ver.windows_server_2008_r2?

--- a/resources/ou_2008.rb
+++ b/resources/ou_2008.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_ou_2008
 provides :windows_ad_ou_2008
+unified_mode true
 
 default_action :create
 

--- a/resources/ou_2012.rb
+++ b/resources/ou_2012.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_ou_2012
 provides :windows_ad_ou_2012
+unified_mode true
 
 default_action :create
 

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -7,6 +7,7 @@
 
 resource_name :windows_ad_user
 provides :windows_ad_user
+unified_mode true
 
 default_action :create
 

--- a/test/cookbooks/windows_ad_test/recipes/setup_forest.rb
+++ b/test/cookbooks/windows_ad_test/recipes/setup_forest.rb
@@ -16,7 +16,7 @@ windows_ad_domain 'contoso.local' do
   end
   action :create
   restart false
-  notifies :reboot_now, 'reboot[now]', :immediate
+  notifies :reboot_now, 'reboot[now]', :immediately
 end
 
 reboot 'now' do


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.0 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with .delivery/project.toml

 - 1:15 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)

### Issues found and resolved with resources/computer.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
 - 21:1 refactor: `Chef/Style/TrueClassFalseClassResourceProperties` - When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass. (https://docs.chef.io/workstation/cookstyle/chef_style_trueclassfalseclassresourceproperties)
 - 23:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire` - Chef Infra Client 12.4+ includes mixlib/shellout automatically in resources and providers. (https://docs.chef.io/workstation/cookstyle/chef_modernize_unnecessarymixlibshelloutrequire)
 - 100:12 refactor: `Chef/Modernize/ShellOutHelper` - Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`. (https://docs.chef.io/workstation/cookstyle/chef_modernize_shellouthelper)
 - 112:13 refactor: `Chef/Modernize/ShellOutHelper` - Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`. (https://docs.chef.io/workstation/cookstyle/chef_modernize_shellouthelper)

### Issues found and resolved with resources/contact.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
 - 20:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire` - Chef Infra Client 12.4+ includes mixlib/shellout automatically in resources and providers. (https://docs.chef.io/workstation/cookstyle/chef_modernize_unnecessarymixlibshelloutrequire)

### Issues found and resolved with resources/domain.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
 - 15:1 refactor: `Chef/Style/TrueClassFalseClassResourceProperties` - When setting the allowed types for a resource to accept either true or false values it's much simpler to use true and false instead of TrueClass and FalseClass. (https://docs.chef.io/workstation/cookstyle/chef_style_trueclassfalseclassresourceproperties)
 - 22:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire` - Chef Infra Client 12.4+ includes mixlib/shellout automatically in resources and providers. (https://docs.chef.io/workstation/cookstyle/chef_modernize_unnecessarymixlibshelloutrequire)
 - 80:13 refactor: `Chef/Modernize/ShellOutHelper` - Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`. (https://docs.chef.io/workstation/cookstyle/chef_modernize_shellouthelper)
 - 85:12 refactor: `Chef/Modernize/ShellOutHelper` - Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`. (https://docs.chef.io/workstation/cookstyle/chef_modernize_shellouthelper)
 - 91:15 refactor: `Chef/Modernize/ShellOutHelper` - Use the built-in `shell_out` helper available in Chef Infra Client 12.11+ instead of calling `Mixlib::ShellOut.new('foo').run_command`. (https://docs.chef.io/workstation/cookstyle/chef_modernize_shellouthelper)

### Issues found and resolved with resources/group.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
 - 20:1 refactor: `Chef/Modernize/UnnecessaryMixlibShelloutRequire` - Chef Infra Client 12.4+ includes mixlib/shellout automatically in resources and providers. (https://docs.chef.io/workstation/cookstyle/chef_modernize_unnecessarymixlibshelloutrequire)

### Issues found and resolved with resources/group_member.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/ou.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)
 - 20:19 refactor: `Chef/Modernize/FoodcriticComments` - Remove legacy code comments that disable Foodcritic rules (https://docs.chef.io/workstation/cookstyle/chef_modernize_foodcriticcomments)
 - 21:18 convention: `Layout/TrailingWhitespace` - Trailing whitespace detected. (https://rubystyle.guide#no-trailing-whitespace)

### Issues found and resolved with resources/ou_2008.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/ou_2012.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/user.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with test/cookbooks/windows_ad_test/recipes/setup_forest.rb

 - 19:40 refactor: `Chef/Style/ImmediateNotificationTiming` - Use :immediately instead of :immediate for resource notification timing (https://docs.chef.io/workstation/cookstyle/chef_style_immediatenotificationtiming)